### PR TITLE
Message formatting fix #58 (#61)

### DIFF
--- a/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/GroupMe.kt
@@ -14,7 +14,7 @@ object GroupMe : MessagingService(MAX_MESSAGE_LENGTH) {
             val formatted = formatMessage(message);
             val response = Unirest.post(URL)
                 .header("Content-Type", "application/json")
-                .body("{\"text\" : \"$formatted\"}, \"bot_id\" : \"$it\"}")
+                .body("{\"text\" : \"$formatted\", \"bot_id\" : \"$it\"}")
                 .asString()
             println("Status Text: " + response.statusText + " | Status: " + response.status)
         }

--- a/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
+++ b/bot/src/main/kotlin/bot/messaging_services/MessagingService.kt
@@ -20,7 +20,7 @@ abstract class MessagingService(private val maxMessageLength: Int) : Consumer<St
                 sendMessage(correctMessage(subMessage))
                 createMessage(message.substring(maxMessageLength + 1))
             }
-            sendMessage(message)
+            sendMessage(correctMessage(message))
         } catch (e : Exception) {
             println(e.localizedMessage)
         }


### PR DESCRIPTION
- fixes erroneous } in json message
- adds correctMessage to sendMessage outside of if statement so messages still get sent properly